### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ prep:
 # Cleanup
 clean: kill
 	$(DOCKER_COMPOSE_ALL) down --volumes --remove-orphans
-	$(DOCKER_COMPOSE_ALL) rm -f
+	$(DOCKER_COMPOSE_ALL) rm -vf
 	docker network prune -f
 	$(MAKE) clean-files
 	# PLANNED: remove __pycache__ dirs


### PR DESCRIPTION
`docker-compose rm -f`, does not remove anonymous volumes associated with a container and they can therefore persist across specific instances of the container. In this particular instance it doesn't matter because it follows `docker-compose down --volumes`, but in case this line is copy-pasted elsewhere, having the `-v` included seems like a good idea.